### PR TITLE
Replace failure with anyhow.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,7 @@ quote = "1.0"
 enum-utils-from-str = { path = "from-str", version = "0.1.2" }
 serde_derive_internals = "0.25"
 syn = { version = "1.0", features = ["extra-traits"] }
-
-[dependencies.failure]
-version = "0.1"
-default-features = false
-features = ["std"]
+anyhow = "1.0"
 
 [dev-dependencies]
 version-sync = "0.8"

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1,4 +1,4 @@
-use failure::format_err;
+use anyhow::format_err;
 use proc_macro2::{TokenStream, Span};
 use quote::quote;
 

--- a/src/from_str.rs
+++ b/src/from_str.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use failure::format_err;
+use anyhow::format_err;
 use proc_macro2::TokenStream;
 use quote::quote;
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,6 +1,6 @@
 use std::ops::{Range, RangeInclusive};
 
-use failure::format_err;
+use anyhow::format_err;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 


### PR DESCRIPTION
Hi!

Failure is deprecated and has security vulnerabilities.

This PR replaces failure with anyhow, which is for the most part a drop in replacement.

Thanks